### PR TITLE
Feature/validate subscription term details

### DIFF
--- a/vendor/forms.py
+++ b/vendor/forms.py
@@ -68,8 +68,10 @@ class OfferForm(forms.ModelForm):
                 self.cleaned_data['name'] = product_names[0]
             else:
                 self.cleaned_data['name'] = _("Bundle: ") + ", ".join(product_names)
-
-        if self.data['terms'] == TermType.SUBSCRIPTION and not cleaned_data['term_details']:
+        
+        term_detail_defaults = [ False for default in list(offer_term_details_default().key()) if default not in cleaned_data['term_details']]
+        
+        if self.data['terms'] == TermType.SUBSCRIPTION and False in term_detail_defaults:
             self.add_error('term_details', _("Invalid term details for subscription"))
 
         return cleaned_data

--- a/vendor/models/offer.py
+++ b/vendor/models/offer.py
@@ -24,13 +24,13 @@ from .utils import set_default_site_id, is_currency_available
 def offer_term_details_default():
     """
     Sets the default term values as a monthly subscription for a 
-    period of 12 months, with not trail days
+    period of 12 months, with 0 trail months 
     """
     return { 
         'period_length': 1,
         'payment_occurrences': 12,
         "term_units": TermDetailUnits.MONTH, 
-        "trial_occurrences": 1
+        "trial_occurrences": 0
         }
 
 

--- a/vendor/models/offer.py
+++ b/vendor/models/offer.py
@@ -22,7 +22,14 @@ from .utils import set_default_site_id, is_currency_available
 # OFFER
 #########
 def offer_term_details_default():
-    return { "term_units": TermDetailUnits.MONTH, "trial_occurrences": 1}
+    "Sets the default term values as a monthly subscription for a period of 12 months, with not trail days"
+    return { 
+        'period_length': 1,
+        'payment_occurrences': 12,
+        "term_units": TermDetailUnits.MONTH, 
+        "trial_occurrences": 1
+        }
+
 
 class ActiveManager(models.Manager):
     """

--- a/vendor/models/offer.py
+++ b/vendor/models/offer.py
@@ -22,7 +22,10 @@ from .utils import set_default_site_id, is_currency_available
 # OFFER
 #########
 def offer_term_details_default():
-    "Sets the default term values as a monthly subscription for a period of 12 months, with not trail days"
+    """
+    Sets the default term values as a monthly subscription for a 
+    period of 12 months, with not trail days
+    """
     return { 
         'period_length': 1,
         'payment_occurrences': 12,

--- a/vendor/processors/base.py
+++ b/vendor/processors/base.py
@@ -175,14 +175,12 @@ class PaymentProcessorBase(object):
             receipt.auto_renew = False
         elif term_type == TermType.SUBSCRIPTION:
             total_months = int(order_item.offer.term_details['period_length']) * int(order_item.offer.term_details['payment_occurrences'])
-            receipt.end_date = self.get_future_date_months(today, total_months)
-            receipt.auto_renew = True
         else:
             total_months = term_type - 100                                             # Get if it is monthy, bi-monthly, quartarly of annually
-            trial_offset = self.get_payment_schedule_start_date(order_item)      # If there are any trial days or months you need to offset it on the end date. 
-            receipt.end_date = self.get_future_date_months(trial_offset, total_months)
-            receipt.auto_renew = True
 
+        trial_offset = self.get_payment_schedule_start_date(order_item)      # If there are any trial days or months you need to offset it on the end date. 
+        receipt.end_date = self.get_future_date_months(trial_offset, total_months)
+        receipt.auto_renew = True
         return receipt
 
     def create_order_item_receipt(self, order_item):

--- a/vendor/processors/base.py
+++ b/vendor/processors/base.py
@@ -176,11 +176,12 @@ class PaymentProcessorBase(object):
         elif term_type == TermType.SUBSCRIPTION:
             total_months = int(order_item.offer.term_details['period_length']) * int(order_item.offer.term_details['payment_occurrences'])
         else:
-            total_months = term_type - 100                                             # Get if it is monthy, bi-monthly, quartarly of annually
-
-        trial_offset = self.get_payment_schedule_start_date(order_item)      # If there are any trial days or months you need to offset it on the end date. 
-        receipt.end_date = self.get_future_date_months(trial_offset, total_months)
-        receipt.auto_renew = True
+            total_months = term_type - 100    
+                                                     # Get if it is monthy, bi-monthly, quartarly of annually
+        if term_type < TermType.PERPETUAL:
+            trial_offset = self.get_payment_schedule_start_date(order_item)      # If there are any trial days or months you need to offset it on the end date. 
+            receipt.end_date = self.get_future_date_months(trial_offset, total_months)
+            receipt.auto_renew = True
         return receipt
 
     def create_order_item_receipt(self, order_item):


### PR DESCRIPTION
Validation on the term details field to at least have the default keys. They allow for the calculation of the end date of a subscription