### PR TITLE
Release v0.2.5

### DIFF
--- a/vendor/__version__.py
+++ b/vendor/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.3"
+VERSION = "0.2.4"

--- a/vendor/__version__.py
+++ b/vendor/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.4"
+VERSION = "0.2.5"

--- a/vendor/processors/base.py
+++ b/vendor/processors/base.py
@@ -408,7 +408,6 @@ class PaymentProcessorBase(object):
                                invoice=self.invoice,
                                created=timezone.now())
         self.payment.result = payment_info
-        self.payment.result['first'] = False
 
         self.transaction_submitted = True
 


### PR DESCRIPTION
Notes:

Migration 0024 was having issues with migrations in parent projects because it was using auth.User default model. The migration was changed to use: settings.AUTH_USER_MODEL. MAKE SURE YOU HAVE THAT SET UP IN YOU SETTING.PY FILE.