### PR TITLE
Get Status Display Offer

### DIFF
--- a/develop/core/tests/test_offers.py
+++ b/develop/core/tests/test_offers.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.test import TestCase, Client
@@ -143,6 +144,27 @@ class ModelOfferTests(TestCase):
         offer = Offer.objects.get(pk=4)
 
         self.assertEquals(offer.get_best_currency('jpy'), 'usd')
+
+    def test_get_status_display_active(self):
+        offer = Offer.objects.get(pk=1)
+        offer.start_date = (timezone.now() - timedelta(days=1))
+        offer.end_date = (timezone.now() + timedelta(days=4))
+        offer.save()
+        self.assertEqual(offer.get_status_display(), "Active")
+
+    def test_get_status_display_scheduled(self):
+        offer = Offer.objects.get(pk=1)
+        offer.start_date = (timezone.now() + timedelta(days=2))
+        offer.end_date = None
+        offer.save()
+        self.assertEqual(offer.get_status_display(), "Scheduled")
+
+    def test_get_status_display_expired(self):
+        offer = Offer.objects.get(pk=1)
+        offer.start_date = (timezone.now() - timedelta(days=5))
+        offer.end_date = (timezone.now() - timedelta(days=1))
+        offer.save()
+        self.assertEqual(offer.get_status_display(), "Expired")
 
 
 class ViewOfferTests(TestCase):

--- a/vendor/models/offer.py
+++ b/vendor/models/offer.py
@@ -85,12 +85,12 @@ class Offer(CreateUpdateModelBase):
         return self.name
 
     def get_status_display(self):
-        if timezone.now() >= self.start_date and (timezone.now() <= self.end_date or self.end_date is None):
-            return _("Active")
+        if self.end_date is not None and timezone.now() > self.end_date:
+            return _("Expired")
         elif timezone.now() < self.start_date:
             return _("Scheduled")
-        elif self.end_date is not None and timezone.now() > self.end_date():
-            return _("Expired")
+        elif timezone.now() >= self.start_date:
+            return _("Active")
 
     def get_msrp(self, currency=DEFAULT_CURRENCY):
         """

--- a/vendor/models/offer.py
+++ b/vendor/models/offer.py
@@ -84,6 +84,14 @@ class Offer(CreateUpdateModelBase):
     def __str__(self):
         return self.name
 
+    def get_status_display(self):
+        if timezone.now() >= self.start_date and (timezone.now() <= self.end_date or self.end_date is None):
+            return _("Active")
+        elif timezone.now() < self.start_date:
+            return _("Scheduled")
+        elif self.end_date is not None and timezone.now() > self.end_date():
+            return _("Expired")
+
     def get_msrp(self, currency=DEFAULT_CURRENCY):
         """
         Gets the sum of the products msrp cost for products.


### PR DESCRIPTION
Notes:

Added a simple method to get display information on the status for the offer, depending on the start and end date. 
<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>