### PR TITLE
Product Owners, Expired Owners and their receipts

### DIFF
--- a/develop/core/tests/test_customer_profile.py
+++ b/develop/core/tests/test_customer_profile.py
@@ -73,6 +73,9 @@ class ModelCustomerProfileTests(TestCase):
         self.assertEquals(count, customer_profile.invoices.first().order_items.count())
 
     def test_owns_product_true(self):
+        receipt = Receipt.objects.get(pk=1)
+        receipt.end_date = None
+        receipt.save()
         product = Product.objects.get(pk=2)
         self.assertTrue(self.customer_profile_existing.has_product(product))
 

--- a/develop/core/tests/test_products.py
+++ b/develop/core/tests/test_products.py
@@ -115,13 +115,11 @@ class ModelProductTests(TestCase):
         receipt.end_date = None
         receipt.save()
         product = Product.objects.get(pk=2)
-        self.assertEqual(1, len(product.active_receipts()))
-        pass
+        self.assertEqual(1, len(product.active_profile_receipts()))
 
     def test_inactive_profile_receipts(self):
         product = Product.objects.get(pk=2)
-        self.assertEqual(0, len(product.inactive_receipts()))
-        pass
+        self.assertEqual(0, len(product.inactive_profile_receipts()))
 
 
 class TransactionProductTests(TestCase):

--- a/develop/core/tests/test_products.py
+++ b/develop/core/tests/test_products.py
@@ -9,9 +9,10 @@ from django.urls import reverse
 from django.utils import timezone
 
 from vendor.models import generate_sku, validate_msrp_format, validate_msrp
-from vendor.models import Offer, Receipt
+from vendor.models import Offer, Receipt, CustomerProfile
 
 User = get_user_model()
+
 
 class ModelProductTests(TestCase):
 
@@ -28,7 +29,7 @@ class ModelProductTests(TestCase):
         self.new_product.save()
 
         self.assertTrue(self.new_product.pk)
-        
+
     def test_unique_sku(self):
         product_a = Product()
         product_a.name = 'a'
@@ -60,11 +61,10 @@ class ModelProductTests(TestCase):
         self.assertEqual(product_a.slug, product_b.slug)
 
     def test_valid_msrp(self):
-        msrp =  "JPY,10.99"
-        
+        msrp = "JPY,10.99"
+
         self.assertIsNone(validate_msrp_format(msrp))
-        
-    
+
     def test_raise_error_invalid_country_code_msrp(self):
         msrp = "JP,10.00"
         with self.assertRaises(ValidationError):
@@ -79,20 +79,20 @@ class ModelProductTests(TestCase):
         msrp = ",10.00"
         with self.assertRaises(ValidationError):
             validate_msrp_format(msrp)
-    
+
     def test_raise_error_only_comma_msrp(self):
         msrp = ","
         with self.assertRaises(ValidationError):
             validate_msrp_format(msrp)
-    
+
     def test_get_best_currency_success(self):
         product = Product.objects.get(pk=1)
-        
+
         self.assertEquals(product.get_best_currency(), 'usd')
 
     def test_get_best_currency_fail(self):
         product = Product.objects.get(pk=1)
-        
+
         self.assertEquals(product.get_best_currency('mxn'), 'usd')
 
     def test_create_product_valid_msrp(self):
@@ -115,11 +115,23 @@ class ModelProductTests(TestCase):
         receipt.end_date = None
         receipt.save()
         product = Product.objects.get(pk=2)
-        self.assertEqual(1, len(product.active_profile_receipts()))
+        self.assertIn(receipt, product.active_profile_receipts())
 
     def test_inactive_profile_receipts(self):
         product = Product.objects.get(pk=2)
-        self.assertEqual(0, len(product.inactive_profile_receipts()))
+        self.assertIn(Receipt.objects.get(pk=1), product.inactive_profile_receipts())
+
+    def test_product_owners(self):
+        receipt = Receipt.objects.get(pk=1)
+        receipt.start_date = timezone.now()
+        receipt.end_date = None
+        receipt.save()
+        product = Product.objects.get(pk=2)
+        self.assertIn(receipt.profile, product.owners())
+
+    def test_expired_owners(self):
+        product = Product.objects.get(pk=2)
+        self.assertIn(CustomerProfile.objects.get(pk=1), product.expired_owners())
 
 
 class TransactionProductTests(TestCase):

--- a/develop/core/tests/test_products.py
+++ b/develop/core/tests/test_products.py
@@ -6,9 +6,10 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.test import TestCase, Client
 from django.urls import reverse
+from django.utils import timezone
 
 from vendor.models import generate_sku, validate_msrp_format, validate_msrp
-from vendor.models import Offer
+from vendor.models import Offer, Receipt
 
 User = get_user_model()
 
@@ -107,6 +108,20 @@ class ModelProductTests(TestCase):
     def test_create_product_in_valid_msrp(self):
         with self.assertRaises(ValidationError):
             validate_msrp({'msrp': {'default': 'usd', 'usd': 21, 'rub': 20 }})
+
+    def test_active_profile_receipts(self):
+        receipt = Receipt.objects.get(pk=1)
+        receipt.start_date = timezone.now()
+        receipt.end_date = None
+        receipt.save()
+        product = Product.objects.get(pk=2)
+        self.assertEqual(1, len(product.active_receipts()))
+        pass
+
+    def test_inactive_profile_receipts(self):
+        product = Product.objects.get(pk=2)
+        self.assertEqual(0, len(product.inactive_receipts()))
+        pass
 
 
 class TransactionProductTests(TestCase):

--- a/develop/fixtures/unit_test.json
+++ b/develop/fixtures/unit_test.json
@@ -591,7 +591,7 @@
         "profile": 1,
         "order_item": 2,
         "start_date": "2020-10-02T16:53:37.437Z",
-        "end_date": null,
+        "end_date": "2020-11-02T16:53:37.437Z",
         "auto_renew": false,
         "vendor_notes": {},
         "transaction": "7127667",

--- a/vendor/models/base.py
+++ b/vendor/models/base.py
@@ -1,4 +1,5 @@
 import uuid
+from vendor.models.receipt import Receipt
 
 from autoslug import AutoSlugField
 
@@ -114,3 +115,9 @@ class ProductModelBase(CreateUpdateModelBase):
             return currency
         else:
             return self.meta['msrp']['default']
+
+    def active_profile_receipts(self):
+        return [receipt for receipt in self.receipts.all() if receipt.profile.has_product(self)]
+
+    def inactive_profile_receipts(self):
+        return [receipt for receipt in self.receipts.all() if not receipt.profile.hat_product(self)]

--- a/vendor/models/base.py
+++ b/vendor/models/base.py
@@ -1,5 +1,4 @@
 import uuid
-from vendor.models.receipt import Receipt
 
 from autoslug import AutoSlugField
 
@@ -120,4 +119,4 @@ class ProductModelBase(CreateUpdateModelBase):
         return [receipt for receipt in self.receipts.all() if receipt.profile.has_product(self)]
 
     def inactive_profile_receipts(self):
-        return [receipt for receipt in self.receipts.all() if not receipt.profile.hat_product(self)]
+        return [receipt for receipt in self.receipts.all() if not receipt.profile.has_product(self)]

--- a/vendor/models/base.py
+++ b/vendor/models/base.py
@@ -116,7 +116,28 @@ class ProductModelBase(CreateUpdateModelBase):
             return self.meta['msrp']['default']
 
     def active_profile_receipts(self):
+        """
+        Gets currently active reciepts by checking if the customer owns the product
+        """
         return [receipt for receipt in self.receipts.all() if receipt.profile.has_product(self)]
+    
+    def owners(self):
+        """
+        Gets a set list of profiles that own the product
+        """
+        active_receipts = self.active_profile_receipts()
+        return set([receipt.profile for receipt in active_receipts])
 
     def inactive_profile_receipts(self):
+        """
+        Gets a list of reciepts for customers that no longer own the product.
+        """
         return [receipt for receipt in self.receipts.all() if not receipt.profile.has_product(self)]
+
+    def expired_owners(self):
+        """
+        Gets a set list of profiles that no longer own the product
+        """
+        owners = self.owners()
+        inactive_receipts = self.inactive_profile_receipts()
+        return set([receipt.profile for receipt in inactive_receipts if receipt.profile not in owners])


### PR DESCRIPTION
Notes:
- Created active_profile_receipts function to retrieve a list or receipts for profiles that have an active product.
- Created owners function to retrieve a list of profiles that currently own the product.
- Created inactive_profile_receipts function to get the past receipts for profiles that use to have an active product.
- Created expired_owners function to get profiles that use to have an active receipt for the product.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>