### PR TITLE
Stripe: subscription payment

### DIFF
--- a/vendor/processors/authorizenet.py
+++ b/vendor/processors/authorizenet.py
@@ -244,14 +244,17 @@ class AuthorizeNetProcessor(PaymentProcessorBase):
         billing_address.lastName = (self.payment_info.data.get('full_name', "").split(" ")[-1])[:50]
         billing_address.company = self.billing_address.data.get('billing-company', "")[:50]
         address_lines = self.billing_address.data.get('billing-address_1', "")
+
         if self.billing_address.data['billing-address_2']:
             address_lines += f", {self.billing_address.data['billing-address_2']}"
+
         billing_address.address = address_lines
         billing_address.city = self.billing_address.data.get("billing-locality", "")[:40]
         billing_address.state = self.billing_address.data.get("billing-state", "")[:40]
         billing_address.zip = self.billing_address.data.get("billing-postal_code")[:20]
         country = Country(int(self.billing_address.data.get("billing-country")))
         billing_address.country = str(country.name)
+        
         return billing_address
 
     def create_customer(self):

--- a/vendor/processors/stripe_processor.py
+++ b/vendor/processors/stripe_processor.py
@@ -345,7 +345,7 @@ class StripeProcessor(PaymentProcessorBase):
 
         # if 'stripe' not in invoice:
         #     pass 
-        super().autshorize_payment()
+        super().authorize_payment()
 
     def process_payment(self):
         self.transaction_submitted = False

--- a/vendor/processors/stripe_processor.py
+++ b/vendor/processors/stripe_processor.py
@@ -114,25 +114,17 @@ class StripeProcessor(PaymentProcessorBase):
     # Stripe Object Builders
     ##########
     def build_customer(self, customer_profile):
-        customer_data = {
+        return {
             'name': f"{customer_profile.user.first_name} {customer_profile.user.last_name}",
             'email': customer_profile.user.email,
             'metadata': {'site': customer_profile.site}
         }
-        
-        customer = self.stripe_create_object(self.stripe.Customer, customer_data)
-        
-        return customer
     
     def build_product(self, offer):
-        product_data = {
+        return {
             'name': offer.name,
             'metadata': {'site': offer.site}
         }
-
-        product = self.stripe_create_object(self.stripe.Product, product_data)
-        
-        return product
 
     def build_price(self, offer, price):
         if 'stripe' not in offer.meta or 'product_id' not in offer.meta['stripe']:

--- a/vendor/processors/stripe_processor.py
+++ b/vendor/processors/stripe_processor.py
@@ -143,7 +143,6 @@ class StripeProcessor(PaymentProcessorBase):
                 'interval_count': offer.term_details['payment_occurrences'],
                 'usage_type': 'license'
             }
-        price = self.stripe_create_object(self.stripe.Price, price_data)
         
         return price
     
@@ -158,8 +157,6 @@ class StripeProcessor(PaymentProcessorBase):
         if offer.terms < TermType.PERPETUAL:
             coupon_data['duration']: 'once' if offer.term_details['trial_occurrences'] <= 1 else 'repeating'
             coupon_data['duration_in_months']: None if offer.term_details['trial_occurrences'] <= 1 else 'repeating'
-
-        coupon = self.stripe_create_object(self.stripe.Coupon, coupon_data)
         
         return coupon
 
@@ -329,15 +326,11 @@ class StripeProcessor(PaymentProcessorBase):
     ##########
     # Base Processor Transaction Implementations
     ##########
-    def authorize_payment(self):
-        # Given that stripe need customer, product, price to process payment we need to check
-        # that vendor object have those keys.
-        # if 'stripe_id' not in invoice.profile.meta:
-        #     raise ValueError()
-
-        # if 'stripe' not in invoice:
-        #     pass 
-        super().authorize_payment()
+    def pre_authorization(self):
+        """
+        Called before the authorization begins.
+        """
+        pass
 
     def process_payment(self):
         self.transaction_submitted = False
@@ -354,7 +347,7 @@ class StripeProcessor(PaymentProcessorBase):
 
     def subscription_payment(self, subscription):
         payment_method_data = self.build_payment_method()
-        stripe_payment_method = self.stripe_create_object(self.stripe.PaymentMethod(), payment_method_data)
+        stripe_payment_method = self.stripe_create_object(self.stripe.PaymentMethod, payment_method_data)
         
         setup_intent_object = self.build_setup_intent(stripe_payment_method.id)
         stripe_setup_intent = self.stripe_create_object(self.stripe.SetupIntent, setup_intent_object)

--- a/vendor/tests/test_stripe.py
+++ b/vendor/tests/test_stripe.py
@@ -441,7 +441,8 @@ class StripeBuildObjectTests(TestCase):
     def test_build_customer_success(self):
         customer_profile = CustomerProfile.objects.all().first()
 
-        stripe_customer = self.processor.build_customer(customer_profile)
+        customer_data = self.processor.build_customer(customer_profile)
+        stripe_customer = self.stripe_create_object(self.stripe.Customer, customer_data)
         
         self.assertIsNotNone(stripe_customer.id)
         self.assertEqual(f"{customer_profile.user.first_name} {customer_profile.user.last_name}", stripe_customer.name)
@@ -450,7 +451,8 @@ class StripeBuildObjectTests(TestCase):
     def test_build_product_success(self):
         offer = Offer.objects.all().first()
 
-        stripe_product = self.processor.build_product(offer)
+        product_data = self.processor.build_product(offer)
+        stripe_product = self.stripe_create_object(self.stripe.Product, product_data)
 
         self.assertIsNotNone(stripe_product.id)
         self.assertEqual(offer.name, stripe_product.name)
@@ -458,13 +460,17 @@ class StripeBuildObjectTests(TestCase):
     def test_build_price_success(self):
         offer = Offer.objects.all().first()
 
-        stripe_product = self.processor.build_product(offer)
+        product_data = self.processor.build_product(offer)
+        stripe_product = self.stripe_create_object(self.stripe.Product, product_data)
+
         offer.meta['stripe'] = {
             'product_id': stripe_product.id
         }
         offer.save()
         price = offer.prices.first()
-        stripe_price = self.processor.build_price(offer, price)
+
+        price_data = self.processor.build_price(offer, price)
+        stripe_price = self.stripe_create_object(self.stripe.Price, price_data)
 
         self.assertIsNotNone(stripe_price.id)
         self.assertEqual(price.cost, stripe_price.unit_amount)
@@ -473,7 +479,8 @@ class StripeBuildObjectTests(TestCase):
         offer = Offer.objects.all().first()
         price = offer.prices.first()
 
-        stripe_coupon = self.processor.build_coupon(offer, price)
+        coupon_data = self.processor.build_coupon(offer, price)
+        stripe_coupon = self.stripe_create_object(self.stripe.Coupon, coupon_data)
         
         self.assertIsNotNone(stripe_coupon.id)
         self.assertEqual("".join([str(stripe_coupon.amount_off)[:-2], ".", str(stripe_coupon.amount_off)[-2:]]), str((offer.get_msrp() - price.cost)))

--- a/vendor/tests/test_stripe.py
+++ b/vendor/tests/test_stripe.py
@@ -284,7 +284,7 @@ class StripeCRUDObjectTests(TestCase):
     ##########
     # Customer CRUD
     def test_create_customer_success(self):
-        stripe_customer = self.processor.stipe_create_object(self.processor.stripe.Customer, self.cus_norrin_radd)
+        stripe_customer = self.processor.stripe_create_object(self.processor.stripe.Customer, self.cus_norrin_radd)
         
         self.assertIsNotNone(stripe_customer.id)
         self.processor.stripe_delete_object(self.processor.stripe.Customer, stripe_customer.id)
@@ -292,7 +292,7 @@ class StripeCRUDObjectTests(TestCase):
     def test_create_customer_with_address_success(self):
         self.cus_norrin_radd['address'] = self.valid_addr
 
-        stripe_customer = self.processor.stipe_create_object(self.processor.stripe.Customer, self.cus_norrin_radd)
+        stripe_customer = self.processor.stripe_create_object(self.processor.stripe.Customer, self.cus_norrin_radd)
         
         self.assertIsNotNone(stripe_customer.id)
         self.processor.stripe_delete_object(self.processor.stripe.Customer, stripe_customer.id)
@@ -300,7 +300,7 @@ class StripeCRUDObjectTests(TestCase):
     ##########
     # Product CRUD
     def test_create_product_success(self):
-        stripe_product = self.processor.stipe_create_object(self.processor.stripe.Product, self.pro_annual_license)
+        stripe_product = self.processor.stripe_create_object(self.processor.stripe.Product, self.pro_annual_license)
 
         self.assertIsNotNone(stripe_product.id)
         self.processor.stripe_call(stripe.Product.delete, stripe_product.id)
@@ -309,7 +309,7 @@ class StripeCRUDObjectTests(TestCase):
     def test_create_product_no_name_fail(self):
         del(self.pro_monthly_license['name'])
         
-        stripe_product = self.processor.stipe_create_object(self.processor.stripe.Product, self.pro_monthly_license)
+        stripe_product = self.processor.stripe_create_object(self.processor.stripe.Product, self.pro_monthly_license)
         self.assertFalse(self.processor.transaction_submitted)
 
     ##########
@@ -318,29 +318,29 @@ class StripeCRUDObjectTests(TestCase):
         del(self.pro_monthly_license['metadata'])
         self.pri_monthly['product_data'] = self.pro_monthly_license
 
-        stripe_price = self.processor.stipe_create_object(self.processor.stripe.Price, self.pri_monthly)
+        stripe_price = self.processor.stripe_create_object(self.processor.stripe.Price, self.pri_monthly)
 
         self.assertIsNotNone(stripe_price.id)
 
     def test_create_price_product_id_success(self):
-        stripe_product = self.processor.stipe_create_object(self.processor.stripe.Product, self.pro_annual_license)
+        stripe_product = self.processor.stripe_create_object(self.processor.stripe.Product, self.pro_annual_license)
         self.pri_monthly['product'] = stripe_product.id
 
-        stripe_price = self.processor.stipe_create_object(self.processor.stripe.Price, self.pri_monthly)
+        stripe_price = self.processor.stripe_create_object(self.processor.stripe.Price, self.pri_monthly)
 
         self.assertIsNotNone(stripe_price.id)
 
     def test_create_price_invalid_field_fail(self):
         self.pri_monthly['type'] = "This is not a valid field"
 
-        stripe_price = self.processor.stipe_create_object(self.processor.stripe.Price, self.pri_monthly)
+        stripe_price = self.processor.stripe_create_object(self.processor.stripe.Price, self.pri_monthly)
         
         self.assertFalse(self.processor.transaction_submitted)
 
     ##########
     # Coupon CRUD
     def test_create_coupon_success(self):
-        stripe_coupon = self.processor.stipe_create_object(self.processor.stripe.Coupon, self.cou_first_month_free)
+        stripe_coupon = self.processor.stripe_create_object(self.processor.stripe.Coupon, self.cou_first_month_free)
 
         self.assertIsNotNone(stripe_coupon.id)
         stripe_coupon = self.processor.stripe_delete_object(self.processor.stripe.Coupon, stripe_coupon.id)
@@ -348,9 +348,9 @@ class StripeCRUDObjectTests(TestCase):
     ##########
     # Subscription CRUD
     def test_create_subscription_success(self):
-        stripe_cus_norrin_radd = self.processor.stipe_create_object(self.processor.stripe.Customer, self.cus_norrin_radd)
+        stripe_cus_norrin_radd = self.processor.stripe_create_object(self.processor.stripe.Customer, self.cus_norrin_radd)
         
-        stripe_payment_method = self.processor.stipe_create_object(self.processor.stripe.PaymentMethod, self.payment_method)
+        stripe_payment_method = self.processor.stripe_create_object(self.processor.stripe.PaymentMethod, self.payment_method)
 
         setup_intent_object = {
             'customer': stripe_cus_norrin_radd.id,
@@ -359,12 +359,12 @@ class StripeCRUDObjectTests(TestCase):
             'payment_method': stripe_payment_method.id,
             'metadata': self.valid_metadata
         }
-        stripe_setup_intent = self.processor.stipe_create_object(self.processor.stripe.SetupIntent, setup_intent_object)
+        stripe_setup_intent = self.processor.stripe_create_object(self.processor.stripe.SetupIntent, setup_intent_object)
         
-        stripe_pro_monthly = self.processor.stipe_create_object(self.processor.stripe.Product, self.pro_monthly_license)
+        stripe_pro_monthly = self.processor.stripe_create_object(self.processor.stripe.Product, self.pro_monthly_license)
         
         self.pri_monthly['product'] = stripe_pro_monthly.id
-        stripe_price = self.processor.stipe_create_object(self.processor.stripe.Price, self.pri_monthly)
+        stripe_price = self.processor.stripe_create_object(self.processor.stripe.Price, self.pri_monthly)
         
         subscription_obj = {
             'customer': stripe_cus_norrin_radd.id,
@@ -373,7 +373,7 @@ class StripeCRUDObjectTests(TestCase):
             'metadata': self.valid_metadata,
 
         }
-        stripe_subscription = self.processor.stipe_create_object(self.processor.stripe.Subscription, subscription_obj)
+        stripe_subscription = self.processor.stripe_create_object(self.processor.stripe.Subscription, subscription_obj)
 
         self.assertIsNotNone(stripe_subscription.id)
 
@@ -414,8 +414,8 @@ class StripeCRUDObjectTests(TestCase):
     # Setup Intent CRUD
     def test_create_setup_intent_success(self):
 
-        stripe_cus_norrin_radd = self.processor.stipe_create_object(self.processor.stripe.Customer, self.cus_norrin_radd)
-        stripe_payment_method = self.processor.stipe_create_object(self.processor.stripe.PaymentMethod, self.payment_method)
+        stripe_cus_norrin_radd = self.processor.stripe_create_object(self.processor.stripe.Customer, self.cus_norrin_radd)
+        stripe_payment_method = self.processor.stripe_create_object(self.processor.stripe.PaymentMethod, self.payment_method)
         
         setup_intent_object = {
             'customer': stripe_cus_norrin_radd.id,
@@ -424,7 +424,7 @@ class StripeCRUDObjectTests(TestCase):
             'payment_method': stripe_payment_method.id,
             'metadata': self.valid_metadata
         }
-        stripe_setup_intent = self.processor.stipe_create_object(self.processor.stripe.SetupIntent, setup_intent_object)
+        stripe_setup_intent = self.processor.stripe_create_object(self.processor.stripe.SetupIntent, setup_intent_object)
         
         self.assertIsNotNone(stripe_setup_intent.id)
 

--- a/vendor/views/vendor.py
+++ b/vendor/views/vendor.py
@@ -71,7 +71,6 @@ class CartView(TemplateView):
         return render(request, self.template_name, context)
 
 
-
 class AccountInformationView(LoginRequiredMixin, TemplateView):
     template_name = 'vendor/checkout.html'
 
@@ -80,6 +79,7 @@ class AccountInformationView(LoginRequiredMixin, TemplateView):
         clear_session_purchase_data(request)
 
         invoice = get_purchase_invoice(request.user, get_site_from_request(request))
+        
         if not invoice.order_items.count():
             return redirect('vendor:cart')
 
@@ -96,6 +96,7 @@ class AccountInformationView(LoginRequiredMixin, TemplateView):
 
         context['form'] = form
         context['invoice'] = invoice
+
         return render(request, self.template_name, context)
 
     def post(self, request, *args, **kwargs):
@@ -116,6 +117,7 @@ class AccountInformationView(LoginRequiredMixin, TemplateView):
         invoice.customer_notes = {'remittance_email': form.cleaned_data['email']}
         # TODO: Need to add a drop down to select existing address
         shipping_address, created = invoice.profile.get_or_create_address(shipping_address)
+
         if created:
             shipping_address.profile = invoice.profile
             shipping_address.save()
@@ -123,7 +125,6 @@ class AccountInformationView(LoginRequiredMixin, TemplateView):
         invoice.save()
 
         return redirect('vendor:checkout-payment')
-
 
 
 class PaymentView(LoginRequiredMixin, TemplateView):
@@ -134,6 +135,7 @@ class PaymentView(LoginRequiredMixin, TemplateView):
 
     def get(self, request, *args, **kwargs):
         invoice = get_purchase_invoice(request.user, get_site_from_request(request))
+
         if not invoice.order_items.count():
             return redirect('vendor:cart')
 
@@ -154,6 +156,7 @@ class PaymentView(LoginRequiredMixin, TemplateView):
             return redirect('vendor:cart')
 
         credit_card_form = CreditCardForm(request.POST)
+        
         if request.POST.get('billing-same_as_shipping') == 'on':
             billing_address_form = BillingAddressForm(instance=invoice.shipping_address)
             billing_address_form.data = {f'billing-{key}': value for key, value in billing_address_form.initial.items()}


### PR DESCRIPTION
-  refactored builder functions to only return the object data. Function should always do one thing 
-  removed extra empty lines 
-  finished first run of captureing a subscription payment 
-  added build_[payment_method, setup_intent] 
-  added steps to charge for subscriptions on stripe_processor 

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>