### PR TITLE
Create receipts-for-trials

### DIFF
--- a/develop/core/templates/core/account.html
+++ b/develop/core/templates/core/account.html
@@ -55,12 +55,12 @@
                 <div class="font-weight-bold mt-3 w-100">{% trans 'Subscription Plan' %}</div>
                 {% if subscription %}
                 <div class="d-flex mt-2">
-                    <div class="text-primary text-left">{{ subscription.order_item.name }}</div>
+                    <div class="text-primary text-left">{{ subscription.name }}</div>
                     <a class="edit-name-button btn text-primary p-0 ml-auto bg-success" style="width: 1rem;" data-toggle="modal"
                         data-target="#update_subscription"><i class="w-100 fas fa-pen"></i></a>
                 </div>
                 <div class="text-left">
-                    {% blocktrans with terms=subscription.order_item.offer.get_terms_display total=subscription.order_item.total end_date=subscription.end_date|date:"M d, Y" %}
+                    {% blocktrans with terms=subscription.receipts.first.order_item.offer.get_terms_display total=subscription.get_total end_date=subscription.get_next_billing_date|date:"M d, Y" %}
                     Your {{ terms }} plan for ${{ total }} will renew on {{ end_date }}
                     {% endblocktrans %}
                 </div>
@@ -123,6 +123,7 @@
                 <hr class="m-0" />
                 <div class='d-flex flex-row w-100 align-items-center my-3'>
                     {% comment %}
+                    <!-- TODO: Functionalty still needed -->
                     <form id="changeSubscription" class="align-itmes-center" method="post"
                         action="{% url 'vendor:customer-subscription-change-plan' subscription.uuid %}">
                         {% csrf_token %}

--- a/develop/core/tests/test_api.py
+++ b/develop/core/tests/test_api.py
@@ -11,7 +11,7 @@ from unittest import skipIf
 
 from vendor.forms import DateTimeRangeForm
 from vendor.processors.base import PaymentProcessorBase
-from vendor.models import Offer, Price, Receipt
+from vendor.models import Offer, Price, Receipt, Subscription
 
 User = get_user_model()
 
@@ -26,23 +26,23 @@ class VendorAPITest(TestCase):
         self.client.force_login(self.user)
 
     def test_subscription_price_update_success(self):
-        receipt = Receipt.objects.get(pk=3)
+        subscription = Subscription.objects.get(pk=1)
         offer = Offer.objects.get(pk=4)
         price = Price.objects.create(offer=offer, cost=89.99, currency='usd', start_date=timezone.now())
         offer.prices.add(price)
 
         url = reverse('vendor_api:manager-subscription-price-update')
 
-        response = self.client.post(url, data={"receipt_uuid": receipt.uuid, "offer_uuid": offer.uuid})
+        response = self.client.post(url, data={"subscription_uuid": subscription.uuid, "offer_uuid": offer.uuid})
 
-        receipt.refresh_from_db()
+        subscription.refresh_from_db()
 
         self.assertEqual(response.status_code, 302)
-        self.assertIn('price_update', receipt.vendor_notes.keys())
+        self.assertIn('price_update', subscription.meta)
 
     def test_subscription_price_update_fail(self):
         url = reverse('vendor_api:manager-subscription-price-update')
-        response = self.client.post(url, data={"receipt_uuid": "188e45aa-0fdf-4877-ba84-f4c39c0fc41b", "offer_uuid": "188e45aa-0fdf-4877-ba84-f4c39c0fc41b"})
+        response = self.client.post(url, data={"subscription_uuid": "188e45aa-0fdf-4877-ba84-f4c39c0fc41b", "offer_uuid": "188e45aa-0fdf-4877-ba84-f4c39c0fc41b"})
 
         self.assertEqual(response.status_code, 404)
 

--- a/develop/core/views.py
+++ b/develop/core/views.py
@@ -8,7 +8,7 @@ from django.views.generic.list import ListView
 
 from vendor.models import Offer
 from vendor.forms import CreditCardForm
-from vendor.models.choice import PaymentTypes
+from vendor.models.choice import PaymentTypes, SubscriptionStatus
 from vendor.utils import get_site_from_request
 from vendor.views.mixin import ProductRequiredMixin
 
@@ -49,7 +49,7 @@ class AccountView(LoginRequiredMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         
         customer_profile, created = request.user.customer_profile.get_or_create(site=get_site_from_request(request))
-        subscriptions = customer_profile.get_recurring_receipts()
+        subscriptions = customer_profile.subscriptions.filter(status=SubscriptionStatus.ACTIVE)
 
         context['payments'] = customer_profile.payments.filter(success=True)
         context["offers"] = Offer.objects.filter(site=get_site_from_request(request), available=True).order_by('terms')

--- a/vendor/api/v1/authorizenet/views.py
+++ b/vendor/api/v1/authorizenet/views.py
@@ -104,7 +104,8 @@ def subscription_save_transaction(site, transaction_id, transaction_detail):
 
         processor = AuthorizeNetProcessor(site, invoice)
         processor.subscription = subscription
-        processor.renew_subscription(subscription.gateway_id, payment_info, payment_status, payment_success)
+        
+        processor.renew_subscription(subscription, transaction_id, payment_status, payment_success)
         logger.info(f"AuthorizeCaptureAPI subscription_save_transaction creating new payment and receipt for subscription, for {subscription_id}")
         
         return None # No need to continue to create receipt as it is done in the above function

--- a/vendor/api/v1/views.py
+++ b/vendor/api/v1/views.py
@@ -183,11 +183,11 @@ class SubscriptionPriceUpdateView(LoginRequiredMixin, View):
 
     def post(self, request, *args, **kwargs):
         site = get_site_from_request(request)
-        receipt = get_object_or_404(Receipt, profile__site=site, uuid=self.request.POST.get('receipt_uuid'))
+        subscription = get_object_or_404(Subscription, profile__site=site, uuid=self.request.POST.get('subscription_uuid'))
         offer = get_object_or_404(Offer, site=site, uuid=self.request.POST.get('offer_uuid'))
 
-        processor = get_site_payment_processor(site)(site, receipt.order_item.invoice)
-        processor.subscription_update_price(receipt, offer.current_price(), request.user)
+        processor = get_site_payment_processor(site)(site)
+        processor.subscription_update_price(subscription, offer.current_price(), request.user)
         
         return redirect(request.META.get('HTTP_REFERER', self.success_url))
 

--- a/vendor/models/invoice.py
+++ b/vendor/models/invoice.py
@@ -68,6 +68,7 @@ class Invoice(SoftDeleteModelBase, CreateUpdateModelBase):
     def add_offer(self, offer, quantity=1):
 
         order_item, created = self.order_items.get_or_create(offer=offer)
+        
         # make sure the invoice pk is also in the OriderItem
         if not created and order_item.offer.allow_multiple:
             order_item.quantity += quantity
@@ -75,6 +76,7 @@ class Invoice(SoftDeleteModelBase, CreateUpdateModelBase):
 
         self.update_totals()
         self.save()
+
         return order_item
 
     def remove_offer(self, offer, clear=False):

--- a/vendor/models/invoice.py
+++ b/vendor/models/invoice.py
@@ -1,18 +1,20 @@
 import itertools
 import uuid
 
+from allauth.account.signals import user_logged_in
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.sites.models import Site
 from django.contrib.sites.managers import CurrentSiteManager
 from django.db import models
 from django.dispatch import receiver
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
-from allauth.account.signals import user_logged_in
 
 from vendor.models.utils import set_default_site_id
 from vendor.config import DEFAULT_CURRENCY
-from vendor.utils import get_site_from_request
+from vendor.utils import get_site_from_request, get_subscription_start_date
 from .base import CreateUpdateModelBase
 from .choice import CURRENCY_CHOICES, TermType, InvoiceStatus
 from .offer import Offer
@@ -193,19 +195,36 @@ class Invoice(SoftDeleteModelBase, CreateUpdateModelBase):
         the upcoming one.
         """
         recurring_offers = self.order_items.filter(offer__terms__lt=TermType.PERPETUAL)
+
         if not recurring_offers.count():
             return None
+
         next_billing_dates = [order_item.offer.get_next_billing_date() for order_item in recurring_offers]
 
         next_billing_dates.sort()
 
         return next_billing_dates[0]
+    
+    def get_billing_dates_and_prices(self):
+        now = timezone.now()
+        payments_info = {now: self.get_one_time_transaction_total()}
+        
+        for recurring_order_item in self.get_recurring_order_items():
+            offer_total = (recurring_order_item.total - recurring_order_item.discounts)
+            subscription_start_date = get_subscription_start_date(recurring_order_item.offer, self.profile, now)
+
+            payments_info.update({subscription_start_date: payments_info[subscription_start_date] + offer_total})
+
+        sorted_payments = {key: payments_info[key] for key in sorted(payments_info.keys()) }
+        
+        return sorted_payments
 
     def get_next_billing_price(self):
         """
         Returns the price corresponding to the upcoming billing date.
         """
         recurring_offers = self.order_items.filter(offer__terms__lt=TermType.PERPETUAL)
+
         if not recurring_offers.count():
             return None
 

--- a/vendor/models/invoice.py
+++ b/vendor/models/invoice.py
@@ -213,7 +213,10 @@ class Invoice(SoftDeleteModelBase, CreateUpdateModelBase):
             offer_total = (recurring_order_item.total - recurring_order_item.discounts)
             subscription_start_date = get_subscription_start_date(recurring_order_item.offer, self.profile, now)
 
-            payments_info.update({subscription_start_date: payments_info[subscription_start_date] + offer_total})
+            if subscription_start_date in payments_info:
+                payments_info.update({subscription_start_date: payments_info[subscription_start_date] + offer_total})
+            else:
+                payments_info[subscription_start_date] = offer_total
 
         sorted_payments = {key: payments_info[key] for key in sorted(payments_info.keys()) }
         

--- a/vendor/models/profile.py
+++ b/vendor/models/profile.py
@@ -159,7 +159,7 @@ class CustomerProfile(CreateUpdateModelBase):
          return set([receipt.products.first()  for receipt in self.get_active_receipts()])
 
     def get_active_offer_receipts(self, offer):
-        return self.receipts.filter(Q(order_item__offer=offer), Q(end_date__gte=timezone.now()) | Q(end_date=None))
+        return self.receipts.filter(Q(deleted=False), Q(order_item__offer=offer), Q(end_date__gte=timezone.now()) | Q(end_date=None))
 
     def get_active_receipts(self):
         return self.receipts.filter(Q(end_date__gte=timezone.now()) | Q(end_date=None))
@@ -207,3 +207,12 @@ class CustomerProfile(CreateUpdateModelBase):
 
     def get_settled_payments(self):
         return self.payments.filter(deleted=False, status=PurchaseStatus.SETTLED).order_by('amount', 'submitted_date')
+
+    def is_on_trial(self, offer):
+
+        on_trial_receipt = [receipt for receipt in self.get_active_offer_receipts(offer) if 'trial' in receipt.uuid]
+
+        if on_trial_receipt:
+            return True
+
+        return False

--- a/vendor/models/profile.py
+++ b/vendor/models/profile.py
@@ -210,7 +210,7 @@ class CustomerProfile(CreateUpdateModelBase):
 
     def is_on_trial(self, offer):
 
-        on_trial_receipt = [receipt for receipt in self.get_active_offer_receipts(offer) if 'trial' in receipt.uuid]
+        on_trial_receipt = [receipt for receipt in self.get_active_offer_receipts(offer) if receipt.transaction and 'trial' in receipt.transaction]
 
         if on_trial_receipt:
             return True

--- a/vendor/models/profile.py
+++ b/vendor/models/profile.py
@@ -210,7 +210,7 @@ class CustomerProfile(CreateUpdateModelBase):
 
     def is_on_trial(self, offer):
 
-        on_trial_receipt = [receipt for receipt in self.get_active_offer_receipts(offer) if receipt.transaction and 'trial' in receipt.transaction]
+        on_trial_receipt = next((receipt for receipt in self.get_active_offer_receipts(offer) if receipt.transaction and 'trial' in receipt.transaction), None)
 
         if on_trial_receipt:
             return True

--- a/vendor/models/subscription.py
+++ b/vendor/models/subscription.py
@@ -113,11 +113,10 @@ class Subscription(SoftDeleteModelBase, CreateUpdateModelBase):
         return self.receipts.first().order_item.total
 
     def save_payment_info(self, payment_info):
-        if 'payment_info' in self.meta:
+        if 'payment_info' not in self.meta:
             self.meta['payment_info'] = {}
         
         self.meta.update({'payment_info': payment_info})
-        
         self.save()
 
 

--- a/vendor/models/subscription.py
+++ b/vendor/models/subscription.py
@@ -109,4 +109,15 @@ class Subscription(SoftDeleteModelBase, CreateUpdateModelBase):
         
         return True
 
+    def get_total(self):
+        return self.receipts.first().order_item.total
+
+    def save_payment_info(self, payment_info):
+        if 'payment_info' in self.meta:
+            self.meta['payment_info'] = {}
+        
+        self.meta.update({'payment_info': payment_info})
+        
+        self.save()
+
 

--- a/vendor/processors/base.py
+++ b/vendor/processors/base.py
@@ -386,8 +386,8 @@ class PaymentProcessorBase(object):
         Process/subscribies recurring payments throught the payement gateway and creates a payment model for each subscription.
         If a payment is completed it will create a receipt for the subscription
         """
-        # if not self.is_card_valid():
-        #     return None
+        if not self.is_card_valid():
+            return None
 
         for subscription in self.invoice.get_recurring_order_items():
             self.create_payment_model()

--- a/vendor/processors/base.py
+++ b/vendor/processors/base.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from vendor import config
 from vendor.models import Payment, Invoice, Receipt, Subscription
 from vendor.models.choice import PurchaseStatus, SubscriptionStatus, TermType, InvoiceStatus
-from vendor.utils import get_payment_scheduled_end_date
+from vendor.utils import get_payment_scheduled_end_date, get_subscription_start_date, get_future_date_days
 
 ##########
 # SIGNALS
@@ -155,14 +155,46 @@ class PaymentProcessorBase(object):
         self.receipt.transaction = self.payment.transaction
         self.receipt.meta.update(self.payment.result)
         self.receipt.meta['payment_amount'] = self.payment.amount
-        self.receipt.start_date = today
+        self.receipt.start_date = get_subscription_start_date(order_item.offer, self.invoice.profile, today)
         self.receipt.save()
 
         if term_type < TermType.PERPETUAL:
-            self.receipt.end_date = get_payment_scheduled_end_date(order_item.offer)
+            self.receipt.end_date = get_payment_scheduled_end_date(order_item.offer, self.receipt.start_date)
             self.receipt.subscription = self.subscription
             
         self.receipt.save()
+
+    def create_trial_receipt_payment(self, order_item):
+        if self.invoice.profile.has_owned_product(order_item.offer.products.all()):
+            return None  # Trial receipts are only created if the user has not owned the product previously 
+
+        if not order_item.offer.get_trial_days():
+            return None
+
+        today = timezone.now()
+
+        self.payment = Payment.objects.create(
+            profile=self.invoice.profile,
+            amount=0,
+            provider=self.provider,
+            invoice=self.invoice,
+            submitted_date=today,
+            success=True,
+            status=PurchaseStatus.SETTLED,
+            payee_full_name=" ".join([self.invoice.profile.user.first_name, self.invoice.profile.user.last_name])
+        )
+        
+        self.payment.transaction = f"{self.payment.uuid}-trial"
+        self.payment.save()
+
+        self.receipt = Receipt.objects.create(
+            profile=self.invoice.profile,
+            order_item=order_item,
+            transaction=self.payment.transaction,
+            start_date=today,
+            end_date=get_future_date_days(today, order_item.offer.get_trial_days()),
+            subscription=self.subscription
+        )
 
     def create_order_item_receipt(self, order_item):
         """
@@ -171,6 +203,7 @@ class PaymentProcessorBase(object):
         """
         for product in order_item.offer.products.all():
             self.create_receipt_by_term_type(order_item, order_item.offer.terms)
+            self.create_trial_receipt_payment(order_item)
             self.receipt.products.add(product)
 
     def create_receipts(self, order_items):
@@ -353,8 +386,8 @@ class PaymentProcessorBase(object):
         Process/subscribies recurring payments throught the payement gateway and creates a payment model for each subscription.
         If a payment is completed it will create a receipt for the subscription
         """
-        if not self.is_card_valid():
-            return None
+        # if not self.is_card_valid():
+        #     return None
 
         for subscription in self.invoice.get_recurring_order_items():
             self.create_payment_model()

--- a/vendor/templates/vendor/includes/cost_overview.html
+++ b/vendor/templates/vendor/includes/cost_overview.html
@@ -32,11 +32,9 @@
     <span class="text-primary">${{ invoice.total|default_if_none:"0.00"|floatformat:2 }}</span>
   </li>
 
-  {% if invoice.get_billing_dates_and_prices.items %}
   {% for billing_date, billing_total in invoice.get_billing_dates_and_prices.items %}
   <li class="px-0 border-0 d-flex justify-content-between mt-3">
       <span class="text-dark font-italic">{% trans 'Your credit card will be billed on ' %}{{ billing_date|date:"F j, Y" }}</span>
       <span class="font-italic" >${{ billing_total }}</span>
   </li>
   {% endfor %}
-  {% endif %}

--- a/vendor/templates/vendor/includes/cost_overview.html
+++ b/vendor/templates/vendor/includes/cost_overview.html
@@ -32,9 +32,11 @@
     <span class="text-primary">${{ invoice.total|default_if_none:"0.00"|floatformat:2 }}</span>
   </li>
 
-  {% if invoice.get_next_billing_date %}
+  {% if invoice.get_billing_dates_and_prices.items %}
+  {% for billing_date, billing_total in invoice.get_billing_dates_and_prices.items %}
   <li class="px-0 border-0 d-flex justify-content-between mt-3">
-      <span class="text-dark font-italic">{% trans 'Your credit card will be billed on ' %}{{ invoice.get_next_billing_date|date:"F j, Y" }}</span>
-      <span class="font-italic" >${{ invoice.get_next_billing_price }}</span>
+      <span class="text-dark font-italic">{% trans 'Your credit card will be billed on ' %}{{ billing_date|date:"F j, Y" }}</span>
+      <span class="font-italic" >${{ billing_total }}</span>
   </li>
+  {% endfor %}
   {% endif %}

--- a/vendor/templates/vendor/manage/subscription_detail.html
+++ b/vendor/templates/vendor/manage/subscription_detail.html
@@ -12,7 +12,7 @@
       </div>
       <div class='card-body'>
         <h4>{{ object.gateway_id}}</h4>
-        <h4>{{ object.receipts.first.order_item.name}}</h4>
+        <h4>{{ object.name}}</h4>
         <p>{{ object.receipts.first.order_item.offer.offer_description|default_if_none:"" }}</p>
         <div class='row'>
           <div class='d-flex flex-column w-50 px-3 py-2'>

--- a/vendor/templates/vendor/purchase_detail.html
+++ b/vendor/templates/vendor/purchase_detail.html
@@ -59,13 +59,13 @@
                                         </td>
                                 </tr>
                                 {% endif %}
-                                {% if object.status == 20 %}
+                                {% if object.subscription %}
                                 <tr>
                                         <th>{% trans 'Actions' %}</th>
                                         <td>
                                                 {% if object.order_item.offer.terms < 200 %}
                                                 <form method="post" class="ml-auto"
-                                                        action="{% url 'vendor_api:customer-subscription-cancel' object.uuid %}">
+                                                        action="{% url 'vendor_api:customer-subscription-cancel' object.subscription.uuid %}">
                                                         {% csrf_token %}
                                                         <button class="btn btn-sm btn-danger rounded"
                                                                 type="submit">{% trans 'Cancel Subscription' %}</button>

--- a/vendor/tests/test_processor.py
+++ b/vendor/tests/test_processor.py
@@ -1001,10 +1001,6 @@ class AuthorizeNetProcessorTests(TestCase):
             return
 
         active_subscriptions = [ s for s in subscription_list if s['status'] == 'active' ]
-        dummy_receipt = Receipt(order_item=OrderItem.objects.get(pk=2))
-        dummy_receipt.profile = CustomerProfile.objects.get(pk=1)
-        dummy_receipt.transaction = active_subscriptions[0].id.pyval
-
         dummy_subscription = Subscription.objects.create(
             gateway_id=active_subscriptions[0].id.pyval,
             profile=CustomerProfile.objects.get(pk=1),

--- a/vendor/utils.py
+++ b/vendor/utils.py
@@ -61,6 +61,15 @@ def get_payment_scheduled_end_date(offer, start_date=timezone.now()):
     elif units == TermDetailUnits.DAY:
         return get_future_date_days(start_date, offer.get_period_length())
 
+def get_subscription_start_date(offer, profile, start_date=timezone.now()):
+    if profile.is_on_trial(offer):
+        return start_date + timedelta(days=offer.get_trial_days())
+    
+    if not profile.has_owned_product(offer.products.all()):
+        return start_date + timedelta(days=offer.get_trial_days())
+
+    return start_date
+        
 
 def get_display_decimal(amount):
     return Decimal(amount).quantize(Decimal('.00'), rounding=ROUND_UP)


### PR DESCRIPTION
Notes:

- Added is_on_trial method to the Profile model.
- Added get_billing_date_and_prices to the Invoice model.
- Added get_total and save_payment_info methods to the Subscription model.
- Update the AuthorizeNet processor functions to use the subscription model: `subscription_update_price`, `subscription_update_payment`
- The BaseProcessor now create trial receipt if necessary using the following method: `create_trial_receipt_payment`
- Update `subscription_update_price`, `renew_subscription`.
- Created function to help determine a subscription start_date depending if the user already owned or not the product. `get_subscription_start_date`
- Updated templates to show subscription information instead of relaying on the receipts. 

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>