### PR TITLE
updates to failing stripe tests

### DIFF
--- a/vendor/processors/stripe_processor.py
+++ b/vendor/processors/stripe_processor.py
@@ -239,6 +239,11 @@ class StripeProcessor(PaymentProcessorBase):
             logger.error("StripeProcessor missing keys in settings: STRIPE_PUBLIC_KEY")
             raise ValueError("StripeProcessor missing keys in settings: STRIPE_PUBLIC_KEY")
 
+        # TODO handle this better, but needed to get passed this error message
+        # Search is not supported on api version 2016-07-06. Update your API version, or set the API Version of this request to 2020-08-27 or greater.
+        # https://stripe.com/docs/libraries/set-version
+        self.stripe.api_version = '2022-08-01'
+
     ##########
     # Stripe utils
     ##########
@@ -294,17 +299,22 @@ class StripeProcessor(PaymentProcessorBase):
         return delete_result
 
     def stripe_get_object(self, stripe_object_class, object_id):
-        stripe_object = self.stripe_call(stripe_object_class.retreive, object_id)
+        stripe_object = self.stripe_call(stripe_object_class.retrieve, object_id)
 
         return stripe_object
 
     def stripe_update_object(self, stripe_object_class, object_id, object_data):
-        stripe_object = self.stripe_call(stripe_object_class.modify, object_id, **object_data)
+        object_data['sid'] = object_id
+        stripe_object = self.stripe_call(stripe_object_class.modify, object_data)
 
         return stripe_object
 
     def stripe_list_objects(self, stripe_object_class, limit=10, starting_after=None):
-        stripe_objects = self.stripe_call(stripe_object_class.list, limit=limit, starting_after=None)
+        object_data = {
+            'limit': limit,
+            'starting_after': starting_after
+        }
+        stripe_objects = self.stripe_call(stripe_object_class.list, object_data)
 
         return stripe_objects
 
@@ -460,7 +470,7 @@ class StripeProcessor(PaymentProcessorBase):
 
     def update_stripe_customers(self, customers):
         for profile in customers:
-            customer_id = profile.meta['id']
+            customer_id = profile.meta['stripe_id']
             profile_data = self.build_customer(profile)
             existing_stripe_customer = self.stripe_update_object(self.stripe.Customer, customer_id, profile_data)
 
@@ -750,7 +760,6 @@ class StripeProcessor(PaymentProcessorBase):
 
         search_data = self.stripe_query_object(self.stripe.Price, {'query': query})
 
-        return search_data.get()
         if search_data:
             if search_data.get('data', False):
                 return True
@@ -841,7 +850,6 @@ class StripeProcessor(PaymentProcessorBase):
         )
 
         query = self.query_builder.build_search_query(self.stripe.Product, [name_clause, metadata_clause])
-
         search_data = self.stripe_query_object(self.stripe.Product, {'query': query})
 
         if search_data:
@@ -925,7 +933,7 @@ class StripeProcessor(PaymentProcessorBase):
             self.payment.status = PurchaseStatus.CAPTURED
             self.payment.save()
             self.update_invoice_status(InvoiceStatus.COMPLETE)
-            self.process_payment_transaction_response()
+            self.parse_response(subscription=False)
 
     def subscription_payment(self, subscription):
         payment_method_data = self.build_payment_method()


### PR DESCRIPTION
Updates for failing stripe tests:

- Noticed that placing the stripe.delete calls after the final assert were never getting called, so rearranged
- Needed to add stripe.api_version in order to use search functionality
- 5 test remain that fail and I suspect its because you are not able to search for a stripe object immediately after creation (just a hunch since search is new functionality)