### PR TITLE
Term_start_date

### DIFF
--- a/vendor/models/invoice.py
+++ b/vendor/models/invoice.py
@@ -213,7 +213,8 @@ class Invoice(SoftDeleteModelBase, CreateUpdateModelBase):
         
         for recurring_order_item in self.get_recurring_order_items():
             offer_total = (recurring_order_item.total - recurring_order_item.discounts)
-            subscription_start_date = get_subscription_start_date(recurring_order_item.offer, self.profile, now)
+            start_date = recurring_order_item.offer.get_term_start_date(now)
+            subscription_start_date = get_subscription_start_date(recurring_order_item.offer, self.profile, start_date)
 
             if subscription_start_date in payments_info:
                 payments_info.update({subscription_start_date: payments_info[subscription_start_date] + offer_total})

--- a/vendor/models/offer.py
+++ b/vendor/models/offer.py
@@ -116,7 +116,6 @@ class Offer(SoftDeleteModelBase, CreateUpdateModelBase):
 
         return price
 
-
     def add_to_cart_link(self):
         return reverse("vendor_api:add-to-cart", kwargs={"slug": self.slug})
 
@@ -202,7 +201,10 @@ class Offer(SoftDeleteModelBase, CreateUpdateModelBase):
         return False
 
     def get_next_billing_date(self):
-        return get_payment_scheduled_end_date(self)
+        start_date = timezone.now()
+        if self.term_start_date:
+            start_date = self.term_start_date
+        return get_payment_scheduled_end_date(self, start_date)
 
     def get_period_length(self):
         if self.terms == TermType.SUBSCRIPTION:
@@ -233,4 +235,9 @@ class Offer(SoftDeleteModelBase, CreateUpdateModelBase):
             
         return False
     
+    def get_term_start_date(self, start_date=timezone.now()):
+        if self.term_start_date and self.term_start_date > start_date:
+            return self.term_start_date
+        
+        return start_date
 

--- a/vendor/processors/authorizenet.py
+++ b/vendor/processors/authorizenet.py
@@ -142,7 +142,7 @@ class AuthorizeNetProcessor(PaymentProcessorBase):
         """
         transaction = apicontractsv1.createTransactionRequest()
         transaction.merchantAuthentication = self.merchant_auth
-        transaction.refId = self.get_transaction_id()
+        transaction.refId = self.get_transaction_id()[:20]
         return transaction
 
     def create_transaction_type(self, trans_type):

--- a/vendor/processors/authorizenet.py
+++ b/vendor/processors/authorizenet.py
@@ -284,6 +284,8 @@ class AuthorizeNetProcessor(PaymentProcessorBase):
             term_units=10 (Day), trial_occurrences=7
             start_date = now + 7 days
         """
+        start_date = subscription.offer.get_term_start_date()
+
         payment_schedule = apicontractsv1.paymentScheduleType()
         payment_schedule.interval = apicontractsv1.paymentScheduleTypeInterval()
         payment_schedule.interval.unit = self.get_interval_units(subscription)
@@ -292,10 +294,10 @@ class AuthorizeNetProcessor(PaymentProcessorBase):
         payment_schedule.totalOccurrences = subscription.offer.get_payment_occurrences()
 
         if self.invoice.profile.has_owned_product(subscription.offer.products.all()):
-            payment_schedule.startDate = CustomDate(timezone.now())
+            payment_schedule.startDate = CustomDate(start_date)
             payment_schedule.trialOccurrences = 0
         else:
-            payment_schedule.startDate = CustomDate(get_future_date_days(timezone.now(), subscription.offer.get_trial_days()))
+            payment_schedule.startDate = CustomDate(get_future_date_days(start_date, subscription.offer.get_trial_days()))
             payment_schedule.trialOccurrences = subscription.offer.get_trial_occurrences()
                 
         return payment_schedule


### PR DESCRIPTION
Notes:

- Added support for term_start_date for offers that are going to be active on a future date.
- updated teh get_transaction_id to only have the site id with the invoice id.
- On AuthorizeNet added a max length of 20 characters for the transaction_id when set to the reference id on authorizenet.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>