### PR TITLE
Unit_test: update discounts-test

### DIFF
--- a/develop/core/tests/test_invoice.py
+++ b/develop/core/tests/test_invoice.py
@@ -195,7 +195,7 @@ class ModelInvoiceTests(TestCase):
 
     def test_save_discounts_vendor_notes(self):
         free_month_offer = Offer.objects.get(pk=7)
-        discount = free_month_offer.current_price()
+        discount = free_month_offer.current_price() - free_month_offer.get_trial_amount()
         self.new_invoice.add_offer(free_month_offer)
         self.new_invoice.save_discounts_vendor_notes()
         self.assertEqual(self.new_invoice.vendor_notes['discounts'], discount)

--- a/develop/fixtures/unit_test.json
+++ b/develop/fixtures/unit_test.json
@@ -410,7 +410,7 @@
             "payment_occurrences": 12,
             "term_units": 20,
             "trial_occurrences": 1,
-            "trial_amount": 10.0
+            "trial_amount": 0
         },
         "term_start_date": null,
         "available": true,

--- a/vendor/models/offer.py
+++ b/vendor/models/offer.py
@@ -155,7 +155,7 @@ class Offer(SoftDeleteModelBase, CreateUpdateModelBase):
         """
         product_msrp_currencies = [ set(product.meta['msrp'].keys()) for product in self.products.all() ]
 
-        if len(product_msrp_currencies) >= 2:  # fixes IndexError: list index out of range
+        if product_msrp_currencies and len(product_msrp_currencies[0]) >= 2:  # fixes IndexError: list index out of range
             if is_currency_available(product_msrp_currencies[0].union(*product_msrp_currencies[1:]), currency=currency):
                 return currency
 


### PR DESCRIPTION
Notes:

- Update discount unit tests.
- added additional validation on the get_best_currencies. The lenth check should be on the first item of the list if the list is not emtpy. Because the list has a set. 

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>