### PR TITLE
Base processor/subscription-set-active

### DIFF
--- a/develop/core/views.py
+++ b/develop/core/views.py
@@ -56,7 +56,7 @@ class AccountView(LoginRequiredMixin, TemplateView):
 
         if subscriptions:
             context['subscription'] = subscriptions.first()
-            context['payment'] = subscriptions.first().order_item.invoice.payments.filter(success=True).first()
+            context['payment'] = subscriptions.first().payments.filter(success=True).first()
             context['payment_form'] = CreditCardForm(initial={'payment_type': PaymentTypes.CREDIT_CARD})
 
         return render(request, self.template_name, context)

--- a/vendor/processors/base.py
+++ b/vendor/processors/base.py
@@ -474,6 +474,7 @@ class PaymentProcessorBase(object):
             gateway_id=self.subscription_id,
             profile=self.invoice.profile,
             auto_renew=True,
+            status=SubscriptionStatus.ACTIVE
         )
         self.subscription.meta['response'] = self.transaction_info
         self.subscription.save()


### PR DESCRIPTION
Notes:
-  added SubscriptionStatus.ACTIVE after successful purchase in the base processor 

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>