### PR TITLE
Use cleaned data in processor methods

### DIFF
--- a/vendor/__version__.py
+++ b/vendor/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.3.6"
+VERSION = "0.3.7"

--- a/vendor/processors/authorizenet.py
+++ b/vendor/processors/authorizenet.py
@@ -159,9 +159,9 @@ class AuthorizeNetProcessor(PaymentProcessorBase):
         Creates and credit card payment type instance form the payment information set.
         """
         creditCard = apicontractsv1.creditCardType()
-        creditCard.cardNumber = self.payment_info.data.get('card_number')
-        creditCard.expirationDate = "-".join([self.payment_info.data.get('expire_year'), self.payment_info.data.get('expire_month')])
-        creditCard.cardCode = str(self.payment_info.data.get('cvv_number'))
+        creditCard.cardNumber = self.payment_info.cleaned_data.get('card_number')
+        creditCard.expirationDate = "-".join([self.payment_info.cleaned_data.get('expire_year'), self.payment_info.cleaned_data.get('expire_month')])
+        creditCard.cardCode = str(self.payment_info.cleaned_data.get('cvv_number'))
         return creditCard
 
     def create_bank_account_payment(self):
@@ -179,7 +179,7 @@ class AuthorizeNetProcessor(PaymentProcessorBase):
         """
         payment = apicontractsv1.paymentType()
         payment.creditCard = self.payment_type_switch[int(
-            self.payment_info.data.get('payment_type'))]()
+            self.payment_info.cleaned_data.get('payment_type'))]()
         return payment
 
     def create_customer_data(self):
@@ -236,19 +236,19 @@ class AuthorizeNetProcessor(PaymentProcessorBase):
         Creates Billing address to improve security in transaction
         """
         billing_address = api_address_type
-        billing_address.firstName = " ".join(self.payment_info.data.get('full_name', "").split(" ")[:-1])[:50]
-        billing_address.lastName = (self.payment_info.data.get('full_name', "").split(" ")[-1])[:50]
-        billing_address.company = self.billing_address.data.get('billing-company', "")[:50]
-        address_lines = self.billing_address.data.get('billing-address_1', "")
+        billing_address.firstName = " ".join(self.payment_info.cleaned_data.get('full_name', "").split(" ")[:-1])[:50]
+        billing_address.lastName = (self.payment_info.cleaned_data.get('full_name', "").split(" ")[-1])[:50]
+        billing_address.company = self.billing_address.cleaned_data.get('company', "")[:50]
+        address_lines = self.billing_address.cleaned_data.get('address_1', "")
 
-        if self.billing_address.data['billing-address_2']:
-            address_lines += f", {self.billing_address.data['billing-address_2']}"
+        if self.billing_address.cleaned_data.get('address_2'):
+            address_lines += f", {self.billing_address.cleaned_data['address_2']}"
 
         billing_address.address = address_lines
-        billing_address.city = self.billing_address.data.get("billing-locality", "")[:40]
-        billing_address.state = self.billing_address.data.get("billing-state", "")[:40]
-        billing_address.zip = self.billing_address.data.get("billing-postal_code")[:20]
-        country = Country(int(self.billing_address.data.get("billing-country")))
+        billing_address.city = self.billing_address.cleaned_data.get("locality", "")[:40]
+        billing_address.state = self.billing_address.cleaned_data.get("state", "")[:40]
+        billing_address.zip = self.billing_address.cleaned_data.get("postal_code")[:20]
+        country = Country(int(self.billing_address.cleaned_data.get("country")))
         billing_address.country = str(country.name)
         
         return billing_address

--- a/vendor/processors/stripe_processor.py
+++ b/vendor/processors/stripe_processor.py
@@ -486,21 +486,21 @@ class StripeProcessor(PaymentProcessorBase):
         return {
             'type': 'card',
             'card': {
-                'number': self.payment_info.data.get('card_number'),
-                'exp_month': self.payment_info.data.get('expire_month'),
-                'exp_year': self.payment_info.data.get('expire_year'),
-                'cvc': self.payment_info.data.get('cvv_number'),
+                'number': self.payment_info.cleaned_data.get('card_number'),
+                'exp_month': self.payment_info.cleaned_data.get('expire_month'),
+                'exp_year': self.payment_info.cleaned_data.get('expire_year'),
+                'cvc': self.payment_info.cleaned_data.get('cvv_number'),
             },
             'billing_details': {
                 'address': {
-                    'line1': self.billing_address.data.get('billing-address_1', None),
-                    'line2': self.billing_address.data.get('billing-address_2', None),
-                    'city': self.billing_address.data.get("billing-locality", ""),
-                    'state': self.billing_address.data.get("billing-state", ""),
-                    'country': Country.names[Country.values.index(int(self.billing_address.data.get("billing-country")))],
-                    'postal_code': self.billing_address.data.get("billing-postal_code")
+                    'line1': self.billing_address.cleaned_data.get('address_1', None),
+                    'line2': self.billing_address.cleaned_data.get('address_2', None),
+                    'city': self.billing_address.cleaned_data.get("locality", ""),
+                    'state': self.billing_address.cleaned_data.get("state", ""),
+                    'country': Country.names[Country.values.index(int(self.billing_address.cleaned_data.get("country")))],
+                    'postal_code': self.billing_address.cleaned_data.get("postal_code")
                 },
-                'name': self.payment_info.data.get('full_name', None),
+                'name': self.payment_info.cleaned_data.get('full_name', None),
                 'email': self.invoice.profile.user.email
             }
         }

--- a/vendor/tests/test_authorizenet.py
+++ b/vendor/tests/test_authorizenet.py
@@ -694,6 +694,7 @@ class AuthorizeNetProcessorTests(TestCase):
 
         if active_subscriptions:
             self.processor.set_payment_info_form_data(self.form_data['credit_card_form'], CreditCardForm)
+            self.processor.payment_info.is_valid()
             self.processor.subscription_update_payment(subscription)
             subscription.refresh_from_db()
             print(f'\ntest_subscription_update_payment\nMessage: {self.processor.transaction_info}\nResponse: {self.processor.transaction_response}\nSubscription ID: {subscription.gateway_id}\n')


### PR DESCRIPTION
* Use cleaned data in the processor methods used when checking a credit card's validity- needed to fix a problem i'm having in TC. previously they took directly from the form data and were prone to throwing errors if form prefixes did not match. @rhimmelbauer let me know if there's any reason these cant use the cleaned_data attribute (which relies on field name and should be more reliable) instead!