### PR TITLE
Fix/Stripe cancellation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ universal = true
 
 [project]
 name = "django-vendor"
-version = "0.3.20"
+version = "0.3.21"
 
 authors = [
   { name="Grant Viklund", email="renderbox@gmail.com" },

--- a/src/vendor/processors/stripe_processor.py
+++ b/src/vendor/processors/stripe_processor.py
@@ -1290,3 +1290,8 @@ class StripeProcessor(PaymentProcessorBase):
 
         if self.transaction_succeeded:
             self.transaction_id = stripe_invoice.payment_intent
+
+
+    def subscription_cancel(self, subscription):
+        super().subscription_cancel(subscription)
+        self.stripe_delete_object(self.stripe.Subscription, subscription.gateway_id)

--- a/src/vendor/views/vendor.py
+++ b/src/vendor/views/vendor.py
@@ -314,7 +314,7 @@ class SubscriptionUpdatePaymentView(LoginRequiredMixin, FormView):
             return redirect(request.META.get('HTTP_REFERER', self.success_url))
 
         processor = get_site_payment_processor(subscription.profile.site)(subscription.profile.site)
-        processor.set_payment_info_form_data(request.POST, CreditCardForm)
+        processor.payment_info = payment_form
         processor.subscription_update_payment(subscription)
 
         if not processor.transaction_succeeded:


### PR DESCRIPTION
* Send signal to stripe to cancel a subscription when it is cancelled on the platform (tested and confirmed locally). solution based on [stripe docs](https://stripe.com/docs/api/subscriptions/cancel?lang=python)
* Fix error when trying to update payment method on a subscription via authorize.net
   * i believe stripe update payment method still needs to be implemented