### PR TITLE
Attempted fixes for 500 errors with stripe subscription renewal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ universal = true
 
 [project]
 name = "django-vendor"
-version = "0.3.22"
+version = "0.3.23"
 
 authors = [
   { name="Grant Viklund", email="renderbox@gmail.com" },


### PR DESCRIPTION
* Attempted fixes for [TC-4185](https://whitemoondreams.atlassian.net/browse/TC-4185): error comparing naive and aware datetimes; error when there is a receipt or payment that needs to be updated but not both. 
* Return a 200 if there is no receipt or payment that needs to be updated when the invoice is paid, because the subscription renewal task may have already done so if this is a recurring payment