### PR TITLE
Stripe user_message error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ universal = true
 
 [project]
 name = "django-vendor"
-version = "0.4.10"
+version = "0.4.11"
 
 authors = [
   { name="Grant Viklund", email="renderbox@gmail.com" },

--- a/src/vendor/processors/stripe.py
+++ b/src/vendor/processors/stripe.py
@@ -291,7 +291,8 @@ class StripeProcessor(PaymentProcessorBase):
                 'exception': f"{e}\n{func}\n{func_args}:user_message: {user_message}"
             }
             errors = {
-                'error': f"{e}"
+                'error': f"{e}",
+                'user_message': user_message
             }
             self.transaction_info = self.get_transaction_info(raw=raw, errors=errors)
             logger.error(self.transaction_info)


### PR DESCRIPTION
Notes:

- On the StripeProcessor under the `transaction_info['errors']` dictionary I added a user_message key if stripe returns one