### PR TITLE
should return an int if there is no commission

### DIFF
--- a/src/vendor/processors/stripe.py
+++ b/src/vendor/processors/stripe.py
@@ -356,7 +356,7 @@ class StripeProcessor(PaymentProcessorBase):
         if vendor_site_commission.instance:
             return vendor_site_commission.get_key_value('commission')
 
-        return None
+        return 0
   
     def get_application_fee_amount(self, amount):
         vendor_site_commission = VendorSiteCommissionConfig(self.site)


### PR DESCRIPTION
This is causing a bug

```
  File "/Users/wml/Projects/work/trainingcamp-django/.venv/lib/python3.9/site-packages/vendor/processors/stripe.py", line 651, in build_subscription
    total_fee_percentage = self.calculate_fee_percentage(self.invoice.total, stripe_base_fee + stripe_recurring_fee + application_fee)
TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'
```
Because it's returning a None