### PR TITLE
Fix/stripe amount rounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ universal = true
 
 [project]
 name = "django-vendor"
-version = "0.4.17"
+version = "0.4.18"
 
 authors = [
   { name="Grant Viklund", email="renderbox@gmail.com" },

--- a/src/vendor/processors/stripe.py
+++ b/src/vendor/processors/stripe.py
@@ -354,7 +354,9 @@ class StripeProcessor(PaymentProcessorBase):
         fraction_part, whole_part = modf(decimal)
                 
         whole_str = str(whole_part).split('.')[0]
-        fraction_str = str(fraction_part).split('.')[1][:2]
+        # need to use Decimal since floats will not always round as expected
+        rounded_fraction = Decimal(fraction_part).quantize(Decimal('.00'), rounding=ROUND_UP)
+        fraction_str = str(rounded_fraction).split('.')[1]
 
         if len(fraction_str) < 2:
             fraction_str = "0" + fraction_str


### PR DESCRIPTION
Fix rounding issue with floats by using decimal to calculate stripe decimal places

example: a price of 7.77 was previously getting charged as 7.76