### PR TITLE
Fix/decimal to int and billing_start_date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ universal = true
 
 [project]
 name = "django-vendor"
-version = "0.4.18"
+version = "0.4.19"
 
 authors = [
   { name="Grant Viklund", email="renderbox@gmail.com" },

--- a/src/vendor/models/offer.py
+++ b/src/vendor/models/offer.py
@@ -253,22 +253,29 @@ class Offer(SoftDeleteModelBase, CreateUpdateModelBase):
             return True
         return False
     
-    def has_valid_billing_start_date(self, today=timezone.now()):
+    def has_valid_billing_start_date(self, today=None):
+        if today is None:
+            today = timezone.now()
+
         if self.billing_start_date and self.billing_start_date > today:
             return True
         return False
     
-    def get_offer_start_date(self, start_date=timezone.now()):
+    def get_offer_start_date(self, start_date=None):
+        if start_date is None:
+            start_date = timezone.now()
         if self.term_start_date and self.term_start_date > start_date:
             return self.term_start_date
         
         return start_date
 
-    def get_offer_end_date(self, start_date=timezone.now()):
+    def get_offer_end_date(self, start_date=None):
         """
         Determines the start date offset so the payment gateway starts charging the monthly offer
         """
         units = self.term_details.get('term_units', TermDetailUnits.MONTH)
+        if start_date is None:
+            start_date = timezone.now()
         
         if units == TermDetailUnits.MONTH:
             return get_future_date_months(start_date, self.get_period_length())
@@ -276,7 +283,10 @@ class Offer(SoftDeleteModelBase, CreateUpdateModelBase):
         elif units == TermDetailUnits.DAY:
             return get_future_date_days(start_date, self.get_period_length())
     
-    def get_trial_end_date(self, start_date=timezone.now()):
+    def get_trial_end_date(self, start_date=None):
+        if start_date is None:
+            start_date = timezone.now()
+
         if self.billing_start_date and self.billing_start_date > start_date:
             return self.billing_start_date - timedelta(days=1)
         
@@ -292,7 +302,9 @@ class Offer(SoftDeleteModelBase, CreateUpdateModelBase):
 
         return start_date + timedelta(days=self.get_trial_days())
 
-    def get_payment_start_date_trial_offset(self, start_date=timezone.now()):
+    def get_payment_start_date_trial_offset(self, start_date=None):
+        if start_date is None:
+            start_date = timezone.now()
         trial_end_date = self.get_trial_end_date(start_date)
 
         if trial_end_date == start_date:

--- a/src/vendor/processors/stripe.py
+++ b/src/vendor/processors/stripe.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from decimal import Decimal, ROUND_UP
-from math import modf
 
 import stripe
 from django.conf import settings
@@ -350,16 +349,19 @@ class StripeProcessor(PaymentProcessorBase):
     def convert_decimal_to_integer(self, decimal):
         if decimal == 0:
             return 0
-            
-        fraction_part, whole_part = modf(decimal)
-                
+
+        fraction_part = decimal % 1
+        whole_part = decimal - fraction_part
+        rounded_fraction = round(fraction_part, 2)
+
         whole_str = str(whole_part).split('.')[0]
-        # need to use Decimal since floats will not always round as expected
-        rounded_fraction = Decimal(fraction_part).quantize(Decimal('.00'), rounding=ROUND_UP)
-        fraction_str = str(rounded_fraction).split('.')[1]
+        if fraction_part == 0:
+            fraction_str = "00"
+        else:
+            fraction_str = str(rounded_fraction).split('.')[1][:2]
 
         if len(fraction_str) < 2:
-            fraction_str = "0" + fraction_str
+            fraction_str = fraction_str + "0"
 
         stripe_amount = int("".join([whole_str, fraction_str]))
             

--- a/src/vendor/processors/stripe.py
+++ b/src/vendor/processors/stripe.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from decimal import Decimal, ROUND_UP
+from math import modf
 
 import stripe
 from django.conf import settings
@@ -350,15 +351,11 @@ class StripeProcessor(PaymentProcessorBase):
         if decimal == 0:
             return 0
 
-        fraction_part = decimal % 1
-        whole_part = decimal - fraction_part
+        fraction_part, whole_part = modf(decimal)
         rounded_fraction = round(fraction_part, 2)
 
         whole_str = str(whole_part).split('.')[0]
-        if fraction_part == 0:
-            fraction_str = "00"
-        else:
-            fraction_str = str(rounded_fraction).split('.')[1][:2]
+        fraction_str = str(rounded_fraction).split('.')[1][:2]
 
         if len(fraction_str) < 2:
             fraction_str = fraction_str + "0"


### PR DESCRIPTION
* Set None as default when passing in dates so timezone.now() is not cached
* Use round instead of Decimal for converting decimals to ints
* Fix bug with tens digit where, for example, 50.1 would be charged as 50.01 instead of 50.10